### PR TITLE
[BUGFIX] Exclude dev-only files from being exported

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,6 @@
 *                         text=auto
+/tests                    export-ignore
+/.editorconfig            export-ignore
 /.github                  export-ignore
 /.gitattributes           export-ignore
 /.gitignore               export-ignore


### PR DESCRIPTION
This PR excludes the `tests` directory and `.editorconfig` file from being exported in dist archives.