### PR TITLE
[FEATURE] Replace `Config::withHeader` with generic `Config::withRule`

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -34,6 +34,6 @@ $header = Rules\Header::create(
 );
 
 return Config::create()
-    ->withHeader($header)
+    ->withRule($header)
     ->withFinder(static fn (Finder\Finder $finder) => $finder->in(__DIR__))
 ;

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ composer require eliashaeussler/php-cs-fixer-config
 use EliasHaeussler\PhpCsFixerConfig;
 use Symfony\Component\Finder;
 
+// Create header rule
 $header = PhpCsFixerConfig\Rules\Header::create(
     'eliashaeussler/package-name',
     PhpCsFixerConfig\Package\Type::ComposerPackage,
@@ -38,8 +39,17 @@ $header = PhpCsFixerConfig\Rules\Header::create(
     PhpCsFixerConfig\Package\License::GPL3OrLater,
 );
 
+// Create custom rule set
+$ruleSet = PhpCsFixerConfig\Rules\RuleSet::fromArray([
+    'modernize_types_casting' => true,
+    'php_unit_test_case_static_method_calls' => [
+        'call_type' => 'self',
+    ],
+]);
+
 return PhpCsFixerConfig\Config::create()
-    ->withHeader($header)
+    ->withRule($header)
+    ->withRule($ruleSet)
     ->withFinder(static fn (Finder\Finder $finder) => $finder->in(__DIR__))
 ;
 ```

--- a/src/Config.php
+++ b/src/Config.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\PhpCsFixerConfig;
 
 use Symfony\Component\Finder;
 
+use function array_replace_recursive;
 use function is_callable;
 
 /**
@@ -32,11 +33,13 @@ use function is_callable;
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
+ *
+ * @phpstan-import-type TRulesArray from Rules\Rule
  */
 final class Config extends \PhpCsFixer\Config
 {
     /**
-     * @var array<string, array<string, mixed>|bool>
+     * @phpstan-var TRulesArray
      */
     private static array $defaultRules = [
         '@PSR2' => true,
@@ -76,9 +79,13 @@ final class Config extends \PhpCsFixer\Config
         return $config;
     }
 
-    public function withHeader(Rules\Header $header): self
+    public function withRule(Rules\Rule $rule): self
     {
-        return $this->withRules($header->get());
+        $mergedRuleSet = array_replace_recursive($this->getRules(), $rule->get());
+
+        $this->setRules($mergedRuleSet);
+
+        return $this;
     }
 
     /**
@@ -91,19 +98,6 @@ final class Config extends \PhpCsFixer\Config
         }
 
         $this->setFinder($finder);
-
-        return $this;
-    }
-
-    /**
-     * @param array<string, array<string, mixed>|bool> $rules
-     */
-    public function withRules(array $rules): self
-    {
-        $this->setRules([
-            ...$this->getRules(),
-            ...$rules,
-        ]);
 
         return $this;
     }

--- a/src/Rules/RuleSet.php
+++ b/src/Rules/RuleSet.php
@@ -23,18 +23,60 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\PhpCsFixerConfig\Rules;
 
+use function array_diff_key;
+use function array_flip;
+use function array_replace_recursive;
+
 /**
- * Rule.
+ * RuleSet.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  *
- * @phpstan-type TRulesArray array<string, array<string, mixed>|bool>
+ * @phpstan-import-type TRulesArray from Rule
  */
-interface Rule
+final class RuleSet implements Rule
 {
     /**
-     * @phpstan-return TRulesArray
+     * @phpstan-param TRulesArray $rules
      */
-    public function get(): array;
+    public function __construct(
+        private array $rules,
+    ) {
+    }
+
+    public static function create(): self
+    {
+        return new self([]);
+    }
+
+    /**
+     * @phpstan-param TRulesArray $rules
+     */
+    public static function fromArray(array $rules): self
+    {
+        return new self($rules);
+    }
+
+    /**
+     * @phpstan-param TRulesArray $rules
+     */
+    public function add(array $rules): self
+    {
+        $this->rules = array_replace_recursive($this->rules, $rules);
+
+        return $this;
+    }
+
+    public function remove(string ...$rules): self
+    {
+        $this->rules = array_diff_key($this->rules, array_flip($rules));
+
+        return $this;
+    }
+
+    public function get(): array
+    {
+        return $this->rules;
+    }
 }

--- a/tests/src/ConfigTest.php
+++ b/tests/src/ConfigTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\PhpCsFixerConfig\Tests;
 
 use EliasHaeussler\PhpCsFixerConfig as Src;
+use Generator;
 use PHPUnit\Framework;
 use Symfony\Component\Finder;
 
@@ -82,17 +83,12 @@ final class ConfigTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
-    public function withHeaderAddsHeaderRule(): void
+    #[Framework\Attributes\DataProvider('withRulesAddsRuleDataProvider')]
+    public function withRulesAddsRule(Src\Rules\Rule $rule): void
     {
-        $header = Src\Rules\Header::create(
-            'foo/baz',
-            Src\Package\Type::ComposerPackage,
-            Src\Package\Author::create('foo', 'foo@baz.de'),
-        );
+        $this->subject->withRule($rule);
 
-        $this->subject->withHeader($header);
-
-        self::assertRulesAreConfigured($header->get());
+        self::assertRulesAreConfigured($rule->get());
     }
 
     #[Framework\Attributes\Test]
@@ -115,18 +111,27 @@ final class ConfigTest extends Framework\TestCase
         self::assertSame($finder, $this->subject->getFinder());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
-    public function withRulesAddsGivenRules(): void
+    /**
+     * @return Generator<string, array{Src\Rules\Rule}>
+     */
+    public static function withRulesAddsRuleDataProvider(): Generator
     {
-        $this->subject->withRules(['foo' => true]);
+        $header = Src\Rules\Header::create(
+            'foo/baz',
+            Src\Package\Type::ComposerPackage,
+            Src\Package\Author::create('foo', 'foo@baz.de'),
+        );
 
-        self::assertRulesAreConfigured(['foo' => true]);
+        $ruleSet = Src\Rules\RuleSet::fromArray(['foo' => true]);
+
+        yield 'header' => [$header];
+        yield 'rule set' => [$ruleSet];
     }
 
     /**
      * @param array<string, array<string, mixed>|bool> $rules
      */
-    protected function assertRulesAreConfigured(array $rules): void
+    private function assertRulesAreConfigured(array $rules): void
     {
         self::assertSame($rules, array_intersect_assoc($this->subject->getRules(), $rules));
     }

--- a/tests/src/Rules/RuleSetTest.php
+++ b/tests/src/Rules/RuleSetTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/php-cs-fixer-config".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PhpCsFixerConfig\Tests\Rules;
+
+use EliasHaeussler\PhpCsFixerConfig as Src;
+use PHPUnit\Framework;
+
+/**
+ * RuleSetTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class RuleSetTest extends Framework\TestCase
+{
+    private Src\Rules\RuleSet $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = Src\Rules\RuleSet::fromArray([
+            'foo' => true,
+            'baz' => [
+                'hello' => 'world',
+            ],
+        ]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function createReturnsRuleSetWithEmptyArray(): void
+    {
+        $actual = Src\Rules\RuleSet::create();
+
+        self::assertSame([], $actual->get());
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromArrayReturnsRuleSetWithGivenRules(): void
+    {
+        $actual = Src\Rules\RuleSet::fromArray(['foo' => true]);
+
+        self::assertSame(['foo' => true], $actual->get());
+    }
+
+    #[Framework\Attributes\Test]
+    public function addMergesGivenRulesWithConfiguredRules(): void
+    {
+        $this->subject->add([
+            'foo' => false,
+            'baz' => [
+                'dummy' => false,
+                ],
+            ],
+        );
+
+        self::assertSame(
+            [
+                'foo' => false,
+                'baz' => [
+                    'hello' => 'world',
+                    'dummy' => false,
+                ],
+            ],
+            $this->subject->get(),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function removeRemovesGivenRules(): void
+    {
+        $this->subject->remove('baz', 'dummy');
+
+        self::assertSame(['foo' => true], $this->subject->get());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getReturnsConfiguredRuleSet(): void
+    {
+        self::assertSame(
+            [
+                'foo' => true,
+                'baz' => [
+                    'hello' => 'world',
+                ],
+            ],
+            $this->subject->get(),
+        );
+    }
+}


### PR DESCRIPTION
This PR replaces the `Config::withHeader()` method with a generic `Config::withRule()` method (which replaces `Config::withRules()`). In addition, a new `Rules\RuleSet` class has been added.

Custom rules can now added using the new `Rules\RuleSet` class:

```php
use EliasHaeussler\PhpCsFixerConfig;

$ruleSet = PhpCsFixerConfig\Rules\RuleSet::fromArray([
    'modernize_types_casting' => true,
    'php_unit_test_case_static_method_calls' => [
        'call_type' => 'self',
    ],
]);

$config = PhpCsFixerConfig\Config::create()
    ->withRule($ruleSet)
;
```

The header rule must be added the same way:

```php
use EliasHaeussler\PhpCsFixerConfig;

$header = PhpCsFixerConfig\Rules\Header::create(
    'eliashaeussler/package-name',
    PhpCsFixerConfig\Package\Type::ComposerPackage,
    PhpCsFixerConfig\Package\Author::create('Elias Häußler', 'elias@haeussler.dev'),
    PhpCsFixerConfig\Package\License::GPL3OrLater,
);

$config = PhpCsFixerConfig\Config::create()
    ->withRule($header)
;
```