### PR TITLE
[FEATURE] Allow passing custom config to `Config` object

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\PhpCsFixerConfig;
 
+use PhpCsFixer\ConfigInterface;
 use Symfony\Component\Finder;
 
 use function array_replace_recursive;
@@ -98,6 +99,15 @@ final class Config extends \PhpCsFixer\Config
         }
 
         $this->setFinder($finder);
+
+        return $this;
+    }
+
+    public function withConfig(ConfigInterface $config): self
+    {
+        $this->setRules($config->getRules());
+        $this->setRiskyAllowed($config->getRiskyAllowed());
+        $this->setFinder($config->getFinder());
 
         return $this;
     }

--- a/tests/src/ConfigTest.php
+++ b/tests/src/ConfigTest.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\PhpCsFixerConfig\Tests;
 
 use EliasHaeussler\PhpCsFixerConfig as Src;
 use Generator;
+use PhpCsFixer\Config;
 use PHPUnit\Framework;
 use Symfony\Component\Finder;
 
@@ -109,6 +110,23 @@ final class ConfigTest extends Framework\TestCase
         $this->subject->withFinder(static fn () => $finder);
 
         self::assertSame($finder, $this->subject->getFinder());
+    }
+
+    #[Framework\Attributes\Test]
+    public function withConfigMergesGivenConfig(): void
+    {
+        $finder = new Finder\Finder();
+        $config = (new Config())
+            ->setRules(['foo' => true])
+            ->setFinder($finder)
+            ->setRiskyAllowed(false)
+        ;
+
+        $this->subject->withConfig($config);
+
+        self::assertSame(['foo' => true], $this->subject->getRules());
+        self::assertSame($finder, $this->subject->getFinder());
+        self::assertFalse($this->subject->getRiskyAllowed());
     }
 
     /**


### PR DESCRIPTION
This PR introduces a new `Config::withConfig()` method. It can be used to pass an object of type `\PhpCsFixer\Config`, leading to an overwritten rule set, risky setting and Finder instance. This is especially useful in combination with other packages that provide a ready-to-use PHP-CS-Fixer config object (e.g. `typo3/coding-standards`).