### PR TITLE
[FEATURE] Switch from PSR-2 to PER

### DIFF
--- a/src/Rules/Set/DefaultRuleSet.php
+++ b/src/Rules/Set/DefaultRuleSet.php
@@ -41,7 +41,7 @@ final class DefaultRuleSet implements Rules\Rule
     public function get(): array
     {
         return [
-            '@PSR2' => true,
+            '@PER' => true,
             '@Symfony' => true,
             'global_namespace_import' => [
                 'import_classes' => true,
@@ -49,13 +49,6 @@ final class DefaultRuleSet implements Rules\Rule
             ],
             'no_superfluous_phpdoc_tags' => [
                 'allow_mixed' => true,
-            ],
-            'ordered_imports' => [
-                'imports_order' => [
-                    'const',
-                    'class',
-                    'function',
-                ],
             ],
             'trailing_comma_in_multiline' => [
                 'elements' => [

--- a/tests/src/ConfigTest.php
+++ b/tests/src/ConfigTest.php
@@ -52,32 +52,7 @@ final class ConfigTest extends Framework\TestCase
         $actual = Src\Config::create();
 
         self::assertSame(
-            [
-                '@PSR2' => true,
-                '@Symfony' => true,
-                'global_namespace_import' => [
-                    'import_classes' => true,
-                    'import_functions' => true,
-                ],
-                'no_superfluous_phpdoc_tags' => [
-                    'allow_mixed' => true,
-                ],
-                'ordered_imports' => [
-                    'imports_order' => [
-                        'const',
-                        'class',
-                        'function',
-                    ],
-                ],
-                'trailing_comma_in_multiline' => [
-                    'elements' => [
-                        'arguments',
-                        'arrays',
-                        'match',
-                        'parameters',
-                    ],
-                ],
-            ],
+            Src\Rules\Set\DefaultRuleSet::create()->get(),
             $actual->getRules(),
         );
         self::assertTrue($actual->getRiskyAllowed());

--- a/tests/src/Rules/Set/DefaultRulesSetTest.php
+++ b/tests/src/Rules/Set/DefaultRulesSetTest.php
@@ -45,7 +45,7 @@ final class DefaultRulesSetTest extends Framework\TestCase
     public function getReturnsDefaultRules(): void
     {
         $expected = [
-            '@PSR2' => true,
+            '@PER' => true,
             '@Symfony' => true,
             'global_namespace_import' => [
                 'import_classes' => true,
@@ -53,13 +53,6 @@ final class DefaultRulesSetTest extends Framework\TestCase
             ],
             'no_superfluous_phpdoc_tags' => [
                 'allow_mixed' => true,
-            ],
-            'ordered_imports' => [
-                'imports_order' => [
-                    'const',
-                    'class',
-                    'function',
-                ],
             ],
             'trailing_comma_in_multiline' => [
                 'elements' => [


### PR DESCRIPTION
This PR switches the default preset to use the PER rule set instead of PSR-2 (which is pretty outdated nowadays).