### PR TITLE
[TASK] Use PHP 8.2 in all workflows

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           tools: composer:v2, composer-require-checker, composer-unused:0.7
           coverage: none
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           tools: composer:v2
           coverage: pcov
 


### PR DESCRIPTION
Since PHP-CS-Fixer now officially supports PHP 8.2, we can safely switch the PHP version in all workflows.