### PR TITLE
[BUGFIX] Require at least one package author for Header rule

### DIFF
--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/php-cs-fixer-config".
+ *
+ * Copyright (C) 2023-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PhpCsFixerConfig\Exception;
+
+/**
+ * Exception.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+abstract class Exception extends \Exception {}

--- a/src/Exception/NoPackageAuthorsConfigured.php
+++ b/src/Exception/NoPackageAuthorsConfigured.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/php-cs-fixer-config".
+ *
+ * Copyright (C) 2023-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PhpCsFixerConfig\Exception;
+
+/**
+ * NoPackageAuthorsConfigured.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class NoPackageAuthorsConfigured extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'No package authors configured. Please provide at least one package author.',
+            1705934958,
+        );
+    }
+}

--- a/src/Rules/Header.php
+++ b/src/Rules/Header.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\PhpCsFixerConfig\Rules;
 
+use EliasHaeussler\PhpCsFixerConfig\Exception;
 use EliasHaeussler\PhpCsFixerConfig\Package;
 
 use function count;
@@ -54,6 +55,8 @@ final class Header implements Rule
 
     /**
      * @param Package\Author|list<Package\Author> $packageAuthors
+     *
+     * @throws Exception\NoPackageAuthorsConfigured
      */
     public static function create(
         string $packageName,
@@ -64,6 +67,8 @@ final class Header implements Rule
     ): self {
         if (!is_array($packageAuthors)) {
             $packageAuthors = [$packageAuthors];
+        } elseif ([] === $packageAuthors) {
+            throw new Exception\NoPackageAuthorsConfigured();
         }
 
         return new self(

--- a/tests/src/Rules/HeaderTest.php
+++ b/tests/src/Rules/HeaderTest.php
@@ -51,6 +51,20 @@ final class HeaderTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function createThrowsExceptionIfNoPackageAuthorsAreConfigured(): void
+    {
+        $this->expectExceptionObject(
+            new Src\Exception\NoPackageAuthorsConfigured(),
+        );
+
+        Src\Rules\Header::create(
+            'eliashaeussler/php-cs-fixer-config',
+            Src\Package\Type::ComposerPackage,
+            [],
+        );
+    }
+
+    #[Framework\Attributes\Test]
     public function createAllowsArrayOfPackageAuthors(): void
     {
         $subject = Src\Rules\Header::create(


### PR DESCRIPTION
This PR adds a check to ensure at least one package author is configured for the `Header` rule.