### PR TITLE
[FEATURE] Allow to omit package authors in Header rule

### DIFF
--- a/src/Rules/Header.php
+++ b/src/Rules/Header.php
@@ -58,7 +58,7 @@ final class Header implements Rule
     public static function create(
         string $packageName,
         Package\Type $packageType,
-        Package\Author|array $packageAuthors,
+        Package\Author|array $packageAuthors = [],
         Package\CopyrightRange $copyrightRange = null,
         Package\License $license = Package\License::Proprietary,
     ): self {
@@ -102,14 +102,16 @@ final class Header implements Rule
         return trim(<<<HEADER
 This file is part of the {$this->packageType->value} "{$this->packageName}".
 
-{$this->generateCopyrightLines()}
-
-{$this->license->licenseText()}
+{$this->generateCopyrightLines()}{$this->license->licenseText()}
 HEADER);
     }
 
     private function generateCopyrightLines(): string
     {
+        if ([] === $this->packageAuthors) {
+            return '';
+        }
+
         $numberOfPackageAuthors = count($this->packageAuthors);
         $copyright = sprintf('Copyright (C) %s', $this->copyrightRange);
         $lines = [];
@@ -130,6 +132,10 @@ HEADER);
 
             $lines[] = $author;
         }
+
+        // Add empty lines to separate copyright and license text
+        $lines[] = '';
+        $lines[] = '';
 
         return implode(PHP_EOL, $lines);
     }

--- a/tests/src/Rules/HeaderTest.php
+++ b/tests/src/Rules/HeaderTest.php
@@ -51,6 +51,36 @@ final class HeaderTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function createAllowsToOmitPackageAuthors(): void
+    {
+        $subject = Src\Rules\Header::create(
+            'eliashaeussler/php-cs-fixer-config',
+            Src\Package\Type::ComposerPackage,
+            license: Src\Package\License::GPL3OrLater,
+        );
+
+        self::assertSame(
+            <<<'HEADER'
+This file is part of the Composer package "eliashaeussler/php-cs-fixer-config".
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+HEADER,
+            $subject->toString(),
+        );
+    }
+
+    #[Framework\Attributes\Test]
     public function createAllowsArrayOfPackageAuthors(): void
     {
         $subject = Src\Rules\Header::create(


### PR DESCRIPTION
This PR adds support for an empty array of package authors. This effectively allows to omit package authors in Header rule, which was not officially supported previously.