### PR TITLE
[BUGFIX] Simplify date range on identical years in copyright range

### DIFF
--- a/src/Package/CopyrightRange.php
+++ b/src/Package/CopyrightRange.php
@@ -58,6 +58,10 @@ final class CopyrightRange implements Stringable
 
     public function __toString(): string
     {
+        if ($this->from === $this->to) {
+            return (string) $this->to;
+        }
+
         if (null !== $this->from && null !== $this->to) {
             return sprintf('%d-%d', $this->from, $this->to);
         }

--- a/tests/src/Package/CopyrightRangeTest.php
+++ b/tests/src/Package/CopyrightRangeTest.php
@@ -89,6 +89,14 @@ final class CopyrightRangeTest extends Framework\TestCase
         self::assertSame('since 2021', (string) $subject);
     }
 
+    #[Framework\Attributes\Test]
+    public function stringRepresentationDoesNotShowRangeOnIdenticalStartAndEndYear(): void
+    {
+        $subject = Src\Package\CopyrightRange::from(2024, 2024);
+
+        self::assertSame('2024', (string) $subject);
+    }
+
     private static function getCurrentYear(): int
     {
         return (int) date('Y');


### PR DESCRIPTION
When using two identical years in the copyright range, the year should not be displayed as range. This is now fixed with this PR.