### PR TITLE
[FEATURE] Add TYPO3 project as additional package type

### DIFF
--- a/src/Package/Type.php
+++ b/src/Package/Type.php
@@ -35,4 +35,5 @@ enum Type: string
     case ComposerPlugin = 'Composer plugin';
     case SymfonyProject = 'Symfony project';
     case TYPO3Extension = 'TYPO3 CMS extension';
+    case TYPO3Project = 'TYPO3 CMS project';
 }


### PR DESCRIPTION
This pull request introduces a new case to the `Type` enum in `src/Package/Type.php` to support TYPO3 CMS projects.

* [`src/Package/Type.php`](diffhunk://#diff-b8984d2710e63f1ac6cb8e7eaee2cf86ec39f016cffe5d5d3efa8c3bacbaf1bfR38): Added a new case, `TYPO3Project`, to the `Type` enum to represent TYPO3 CMS projects.